### PR TITLE
Allow specifying Mirth Connection version as a build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM java
 
-ARG MIRTH_CONNECT_VERSION=3.3.1.7856.b91
-
 # Mirth Connect is run with user `connect`, uid = 1000
 # If you bind mount a volume from the host or a data container, 
 # ensure you use the same uid
@@ -17,6 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 	&& chmod +x /usr/local/bin/gosu
 
 VOLUME /opt/mirth-connect/appdata
+
+ARG MIRTH_CONNECT_VERSION=3.3.1.7856.b91
 
 RUN \
   cd /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM java
 
-ENV MIRTH_CONNECT_VERSION 3.3.1.7856.b91
+ARG MIRTH_CONNECT_VERSION=3.3.1.7856.b91
 
 # Mirth Connect is run with user `connect`, uid = 1000
 # If you bind mount a volume from the host or a data container, 


### PR DESCRIPTION
Two small changes to allow specifying the Mirth Connection version as a build argument and moving the definition of the variable lower in the file so that when it changes only minimal parts of the file need to be re-run.
